### PR TITLE
Replace MyHikerBox with Company.MobileApp namespace

### DIFF
--- a/content/MobileAppQuickStart-CSharp/src/Company.MobileApp/Services/DebugLogger.cs
+++ b/content/MobileAppQuickStart-CSharp/src/Company.MobileApp/Services/DebugLogger.cs
@@ -3,7 +3,7 @@ using FFImageLoading.Helpers;
 using Prism.Logging;
 using static System.Diagnostics.Debug;
 
-namespace MyHikerBox.Services
+namespace Company.MobileApp.Services
 {
     public class DebugLogger : ILoggerFacade, IMiniLogger
     {

--- a/content/MobileAppQuickStart-CSharp/src/Company.MobileApp/Services/MCAnalyticsLogger.cs
+++ b/content/MobileAppQuickStart-CSharp/src/Company.MobileApp/Services/MCAnalyticsLogger.cs
@@ -4,7 +4,7 @@ using FFImageLoading.Helpers;
 using Microsoft.Azure.Mobile.Analytics;
 using Prism.Logging;
 
-namespace MyHikerBox.Services
+namespace Company.MobileApp.Services
 {
     public class MCAnalyticsLogger : ILoggerFacade, IMiniLogger
     {


### PR DESCRIPTION
The namespace for the `DebugLogger` is off: [See line 6](https://github.com/dansiegel/Prism-Templates/blob/master/content/MobileAppQuickStart-CSharp/src/Company.MobileApp/Services/DebugLogger.cs#L6)

It's `MyHikerBox.Services` where it should be `Company.MobileApp.Services`.