### PR TITLE
Exclude auto generated files in gitignore

### DIFF
--- a/content/MobileAppEmpty-CSharp/GitIgnore
+++ b/content/MobileAppEmpty-CSharp/GitIgnore
@@ -49,6 +49,5 @@ Secrets.cs
 
 # Auto generated files
 project.lock.json
-Company.MobileApp.Droid.nuget.props
-Company.MobileApp.iOS.nuget.props
+Company.MobileApp.*.nuget.*
 

--- a/content/MobileAppEmpty-CSharp/GitIgnore
+++ b/content/MobileAppEmpty-CSharp/GitIgnore
@@ -46,3 +46,9 @@ Certificate/
 
 secrets.json
 Secrets.cs
+
+# Auto generated files
+project.lock.json
+Company.MobileApp.Droid.nuget.props
+Company.MobileApp.iOS.nuget.props
+

--- a/content/MobileAppQuickStart-CSharp/GitIgnore
+++ b/content/MobileAppQuickStart-CSharp/GitIgnore
@@ -49,5 +49,4 @@ Secrets.cs
 
 # Auto generated files
 project.lock.json
-Company.MobileApp.Droid.nuget.props
-Company.MobileApp.iOS.nuget.props
+Company.MobileApp.*.nuget.*

--- a/content/MobileAppQuickStart-CSharp/GitIgnore
+++ b/content/MobileAppQuickStart-CSharp/GitIgnore
@@ -46,3 +46,8 @@ Certificate/
 
 secrets.json
 Secrets.cs
+
+# Auto generated files
+project.lock.json
+Company.MobileApp.Droid.nuget.props
+Company.MobileApp.iOS.nuget.props


### PR DESCRIPTION
I noticed that `project.lock.json` and `Company.MobileApp.(Droid|iOS)` should not be included in the repository.

Both these files seem to be auto generated and have different values between machines, so I always got pending changes when I switch between my laptop and my desktop.